### PR TITLE
Added noEmptyDefault warning suppression. Tests now run w/o warnings.

### DIFF
--- a/2013/src/test/resources/nachaDaffodilConfig.xml
+++ b/2013/src/test/resources/nachaDaffodilConfig.xml
@@ -4,6 +4,6 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<daf:tunables>
      <daf:unqualifiedPathStepPolicy>defaultNamespace</daf:unqualifiedPathStepPolicy>
-     <daf:suppressSchemaDefinitionWarnings>multipleChoiceBranches</daf:suppressSchemaDefinitionWarnings>
+     <daf:suppressSchemaDefinitionWarnings>multipleChoiceBranches noEmptyDefault</daf:suppressSchemaDefinitionWarnings>
     </daf:tunables>
 </daf:dfdlConfig>


### PR DESCRIPTION
Fixes https://github.com/DFDLSchemas/NACHA/issues/2

This pull request may sit unmerged for a while because the release of daffodil that supports the noEmptyDefaults warning suppression isn't released yet. 